### PR TITLE
Faster gcloud services enable_apis.sh script

### DIFF
--- a/Lab-00-Environment-Setup/enable_apis.sh
+++ b/Lab-00-Environment-Setup/enable_apis.sh
@@ -15,13 +15,13 @@
 
 # This script enables the APIs required by the solution
 
-gcloud services enable cloudbuild.googleapis.com
-gcloud services enable container.googleapis.com
-gcloud services enable cloudresourcemanager.googleapis.com
-gcloud services enable iam.googleapis.com
-gcloud services enable containerregistry.googleapis.com
-gcloud services enable containeranalysis.googleapis.com
-gcloud services enable ml.googleapis.com
-gcloud services enable sqladmin.googleapis.com
-gcloud services enable dataflow.googleapis.com
-gcloud services enable automl.googleapis.com
+gcloud services enable cloudbuild.googleapis.com \
+	container.googleapis.com \
+	cloudresourcemanager.googleapis.com \
+	iam.googleapis.com \
+	containerregistry.googleapis.com \
+	containeranalysis.googleapis.com \
+	ml.googleapis.com \
+	sqladmin.googleapis.com \
+	dataflow.googleapis.com \
+	automl.googleapis.com


### PR DESCRIPTION
Refactored gcloud services enable command to enable all APIs in parallel. Changes execution time from 5-15 minutes to 2-5 minutes.

https://cloud.google.com/sdk/gcloud/reference/services/enable