### PR TITLE
lab-21: minor typos in the notebook markdown cells

### DIFF
--- a/labs/lab-21-tfx-walkthrough/tfx-walkthrough.ipynb
+++ b/labs/lab-21-tfx-walkthrough/tfx-walkthrough.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "You will utilize  **TFX Interactive Context** to work with the TFX components interactivelly in a Jupyter notebook environment.\n",
     "\n",
-    "Working in an interactive notebook is useful when doing initial data exploriation, experimenting with models, and designing ML pipelines. You should be aware that there are differences in the way interactive notebooks are orchestrated, and how they access metadata artifacts.\n",
+    "Working in an interactive notebook is useful when doing initial data exploration, experimenting with models, and designing ML pipelines. You should be aware that there are differences in the way interactive notebooks are orchestrated, and how they access metadata artifacts.\n",
     "\n",
     "In a production deployment of TFX on GCP, you will use an orchestrator such as Kubeflow Pipelines, or Cloud Composer. In an interactive mode, the notebook itself is the orchestrator, running each TFX component as you execute the notebook cells.\n",
     "\n",
@@ -197,7 +197,7 @@
    "source": [
     "## Generating statistics using StatisticsGen\n",
     "\n",
-    "The `StatisticsGen`  component generates data statistics that can be used by other TFX components. StatisticsGen uses [TensorFlow Data Validation](https://www.tensorflow.org/tfx/data_validation/get_started). `StatisticsGen` generate statistics for each split in the `ExampleGen` component's output. In our case there two splits: `train` and `eval`."
+    "The `StatisticsGen`  component generates data statistics that can be used by other TFX components. StatisticsGen uses [TensorFlow Data Validation](https://www.tensorflow.org/tfx/data_validation/get_started). `StatisticsGen` generates statistics for each split in the `ExampleGen` component's output. In our case there are two splits: `train` and `eval`."
    ]
   },
   {
@@ -502,7 +502,7 @@
     "\n",
     "### Define the pre-processing module\n",
     "\n",
-    "To configure `Trainsform`, you need to encapsulate your pre-processing code in the Python `preprocessing_fn` function and save it to a  python module that is then provided to the Transform component as an input. This module will be loaded by transform and the `preprocessing_fn` function will be called when the `Transform` component runs.\n",
+    "To configure `Transform`, you need to encapsulate your pre-processing code in the Python `preprocessing_fn` function and save it to a  python module that is then provided to the Transform component as an input. This module will be loaded by transform and the `preprocessing_fn` function will be called when the `Transform` component runs.\n",
     "\n",
     "In most cases, your implementation of the `preprocessing_fn` makes extensive use of [TensorFlow Transform](https://www.tensorflow.org/tfx/guide/tft) for performing feature engineering on your dataset."
    ]
@@ -623,7 +623,7 @@
     "- `transform_output` - contains the graph that can perform the preprocessing operations (this graph will be included in the serving and evaluation models).\n",
     "- `transformed_examples` - contains the preprocessed training and evaluation data.\n",
     "\n",
-    "Take a peek at the `transform_outpu` artifact: it points to a directory containing 3 subdirectories:"
+    "Take a peek at the `transform_output` artifact: it points to a directory containing 3 subdirectories:"
    ]
   },
   {
@@ -682,7 +682,7 @@
     "\n",
     "#### Define the trainer module\n",
     "\n",
-    "To configure `Trainer`, you need to encapsulate your training code in a Python module that is then provided to the `Trainer` as an input. The module must include the `trainer_fn` function that must return an `tf.estimator` based estimator. f you prefer to work with `Keras`, you can do so and then convert the Keras model to an estimator using the `tf.keras.model_to_estimator()` function.\n"
+    "To configure `Trainer`, you need to encapsulate your training code in a Python module that is then provided to the `Trainer` as an input. The module must include the `trainer_fn` function that must return an `tf.estimator` based estimator. If you prefer to work with `Keras`, you can do so and then convert the Keras model to an estimator using the `tf.keras.model_to_estimator()` function.\n"
    ]
   },
   {
@@ -1091,7 +1091,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deploying models with Pushe\n",
+    "## Deploying models with Pusher\n",
     "\n",
     "The `Pusher` component checks whether a model has been \"blessed\", and if so, deploys it by pushing the model to a well known file destination.\n",
     "\n"
@@ -1181,7 +1181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed minor typos in tfx-walkthrough.ipynb (only in the explanations in markdown). 